### PR TITLE
Exclude password reset endpoints from sso redirect.

### DIFF
--- a/ftw/saml2auth/subscribers.py
+++ b/ftw/saml2auth/subscribers.py
@@ -60,6 +60,8 @@ def initiate_saml2_protocol_exchange(event):
             current_url.endswith('/login') or
             current_url.endswith('/mail_password_form') or
             current_url.endswith('/mail_password') or
+            current_url.endswith('/pwreset_finish') or
+            'passwordreset/' in current_url or
             'portal_registration/' in current_url):
         return
 

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -5,8 +5,8 @@ extends =
 package-name = ftw.saml2auth
 
 [versions]
-zc.buildout = 1.7.1
+zc.buildout = 2.12.2
 zc.recipe.egg = 1.3.2
-setuptools = 0.6c11
+setuptools = 33.1.1
 
 lxml = 3.8.0


### PR DESCRIPTION
There were some excluded endpoints missing to be able to perform a password-reset for plone-users.

This PR appends this missing endpoints.