### PR TITLE
Update versionpinnings to fix tests

### DIFF
--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -5,8 +5,8 @@ extends =
 package-name = ftw.saml2auth
 
 [versions]
-zc.buildout = 1.7.1
+zc.buildout = 2.12.2
 zc.recipe.egg = 1.3.2
-setuptools = 0.6c11
+setuptools = 33.1.1
 
 lxml = 3.8.0


### PR DESCRIPTION
This PR fixes the tests through new version-pinnings.

Since pipy.org requires ssl but the currently used setuptools version does not support ssl-connections.